### PR TITLE
feat(theme): flicker-free dark mode with system default and toggle

### DIFF
--- a/themes/nathanhealea/layouts/partials/head.html
+++ b/themes/nathanhealea/layouts/partials/head.html
@@ -27,6 +27,18 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 
+  <!-- Set theme before first paint to avoid a flash of the wrong theme -->
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem('theme');
+        if (stored === 'dark' || stored === 'light') {
+          document.documentElement.setAttribute('data-theme', stored);
+        }
+      } catch (e) {}
+    })();
+  </script>
+
   <link rel="stylesheet" href="{{ "css/main.css" | relURL }}" />
 
   {{ if .IsHome }}

--- a/themes/nathanhealea/layouts/partials/header.html
+++ b/themes/nathanhealea/layouts/partials/header.html
@@ -7,6 +7,22 @@
         <li class="nav-list-item"><a href="#projects" class="nav-link">Projects</a></li>
         <li class="nav-list-item"><a href="#contact" class="nav-link nav-link--cta">Contact</a></li>
       </ul>
+      <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Toggle dark mode">
+        <svg class="theme-toggle__icon theme-toggle__icon--sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+        <svg class="theme-toggle__icon theme-toggle__icon--moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </button>
       <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-list">
         <span></span>
         <span></span>

--- a/themes/nathanhealea/static/css/main.css
+++ b/themes/nathanhealea/static/css/main.css
@@ -2,6 +2,8 @@
    DESIGN TOKENS
    ============================== */
 :root {
+  color-scheme: light;
+
   --color-bg: #ffffff;
   --color-bg-alt: #f8fafc;
   --color-text: #0f172a;
@@ -10,6 +12,7 @@
   --color-accent-dark: #1d4ed8;
   --color-accent-light: #eff6ff;
   --color-border: #e2e8f0;
+  --color-header-bg: rgb(255 255 255 / 0.92);
 
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
 
@@ -23,6 +26,45 @@
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04);
 
   --transition: 150ms ease;
+}
+
+/* Dark theme tokens — shared by an explicit choice and the system default */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg: #0f172a;
+  --color-bg-alt: #1e293b;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-accent: #3b82f6;
+  --color-accent-dark: #60a5fa;
+  --color-accent-light: #1e293b;
+  --color-border: #334155;
+  --color-header-bg: rgb(15 23 42 / 0.85);
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.4);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.55), 0 4px 6px -4px rgb(0 0 0 / 0.45);
+}
+
+/* Follow the OS setting when the visitor hasn't made an explicit choice */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --color-bg: #0f172a;
+    --color-bg-alt: #1e293b;
+    --color-text: #e2e8f0;
+    --color-text-muted: #94a3b8;
+    --color-accent: #3b82f6;
+    --color-accent-dark: #60a5fa;
+    --color-accent-light: #1e293b;
+    --color-border: #334155;
+
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.4);
+    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.55), 0 4px 6px -4px rgb(0 0 0 / 0.45);
+  }
 }
 
 /* ==============================
@@ -215,7 +257,7 @@ button {
   top: 0;
   z-index: 100;
   max-width: 100%;
-  background-color: rgb(255 255 255 / 0.92);
+  background-color: var(--color-header-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid transparent;
@@ -316,6 +358,55 @@ button {
 
 .nav-toggle[aria-expanded="true"] span:nth-child(3) {
   transform: translateY(-7px) rotate(-45deg);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  transition: color var(--transition), background-color var(--transition);
+}
+
+.theme-toggle:hover {
+  color: var(--color-accent);
+  background-color: var(--color-bg-alt);
+}
+
+.theme-toggle__icon {
+  width: 20px;
+  height: 20px;
+}
+
+/* Show moon in light mode, sun in dark mode — mirrors the token selectors */
+.theme-toggle__icon--sun {
+  display: none;
+}
+
+.theme-toggle__icon--moon {
+  display: block;
+}
+
+:root[data-theme="dark"] .theme-toggle__icon--sun {
+  display: block;
+}
+
+:root[data-theme="dark"] .theme-toggle__icon--moon {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-toggle__icon--sun {
+    display: block;
+  }
+
+  :root:not([data-theme="light"]) .theme-toggle__icon--moon {
+    display: none;
+  }
 }
 
 /* ==============================

--- a/themes/nathanhealea/static/js/main.js
+++ b/themes/nathanhealea/static/js/main.js
@@ -56,6 +56,24 @@
 
   activateNavLink();
 
+  // Theme toggle — persist an explicit light/dark choice
+  var themeToggle = document.getElementById('theme-toggle');
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', function () {
+      var root = document.documentElement;
+      var explicit = root.getAttribute('data-theme');
+      var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var isDark = explicit ? explicit === 'dark' : systemDark;
+      var next = isDark ? 'light' : 'dark';
+
+      root.setAttribute('data-theme', next);
+      try {
+        localStorage.setItem('theme', next);
+      } catch (e) {}
+    });
+  }
+
   // Experience — expand/collapse all
   var experienceTimeline = document.getElementById('experience-timeline');
   var experienceToggleAll = document.getElementById('experience-toggle-all');


### PR DESCRIPTION
## Summary

- **Dark theme tokens**: added a dark palette via CSS custom-property overrides, keyed off both an explicit `data-theme="dark"` attribute and `@media (prefers-color-scheme: dark)` so the site follows the OS setting by default. Sets `color-scheme` and darkened shadows for the dark palette.
- **Themed header**: introduced a `--color-header-bg` token so the sticky nav bar goes dark with the rest of the site while keeping the blur effect.
- **Flicker-free load**: a blocking inline `<head>` script applies a stored theme choice before first paint, avoiding a flash of the wrong theme; the system default is handled natively by the CSS media query.
- **Theme toggle**: a sun/moon square button in the nav; the icon reflects the resolved theme and the click handler persists the choice to `localStorage`, while OS changes still apply live when no explicit choice is set.

## Test plan

- [x] Hugo build passes (`hugo --gc --minify`)
- [ ] Visual check: system default (light/dark OS), toggle overrides and persists, no flash on reload in any state
